### PR TITLE
feat: Add modern portfolio page design

### DIFF
--- a/app/component/modern-portfolio/contactBar.tsx
+++ b/app/component/modern-portfolio/contactBar.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import React from 'react'
+import { Box, Typography, IconButton, Tooltip } from '@mui/material'
+
+interface ContactItem {
+    app: string
+    link: string
+    icon?: React.ReactNode // The icon is expected to be a ReactNode (e.g., an MUI icon component)
+}
+
+interface ContactBarProps {
+    contact: ContactItem[]
+}
+
+const ContactBar: React.FC<ContactBarProps> = ({ contact }) => {
+    return (
+        <Box sx={{ paddingY: 4, paddingX: 2, textAlign: 'center' }}>
+            <Typography variant="h4" component="h2" gutterBottom sx={{ marginBottom: 3 }}>
+                Get in Touch
+            </Typography>
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flexWrap: 'wrap', gap: 2 }}>
+                {contact.map((item, index) => (
+                    <Tooltip title={item.app} key={index}>
+                        <IconButton
+                            aria-label={item.app}
+                            href={item.link}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            sx={{
+                                margin: 1, // Add some margin for spacing
+                                color: 'primary.main', // Use primary color for the icon
+                                '&:hover': {
+                                    backgroundColor: 'primary.light', // Optional: subtle background on hover
+                                },
+                                // Increase icon size if they appear too small
+                                // fontSize: '2rem', // Uncomment and adjust if needed
+                            }}
+                        >
+                            {/* Ensure the icon itself has appropriate sizing if it's an SVG component */}
+                            {React.isValidElement(item.icon) ? React.cloneElement(item.icon as React.ReactElement, { sx: { fontSize: '2rem' }}) : null}
+                        </IconButton>
+                    </Tooltip>
+                ))}
+            </Box>
+        </Box>
+    )
+}
+
+export default ContactBar

--- a/app/component/modern-portfolio/experienceTimeline.tsx
+++ b/app/component/modern-portfolio/experienceTimeline.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import React from 'react'
+import { Box, Typography, Chip, Paper } from '@mui/material'
+import {
+    Timeline,
+    TimelineItem,
+    TimelineSeparator,
+    TimelineConnector,
+    TimelineDot,
+    TimelineContent,
+    timelineItemClasses, // Used for removing default styling on the last item
+} from '@mui/lab' // Attempting to import from @mui/lab
+
+interface ExperienceItemProps {
+    from: string
+    to: string
+    company: string
+    location: string
+    position: string
+    keySkills: string[]
+}
+
+interface ExperienceTimelineProps {
+    experience: ExperienceItemProps[]
+}
+
+const ExperienceTimeline: React.FC<ExperienceTimelineProps> = ({ experience }) => {
+    const formatDateRange = (from: string, to: string): string => {
+        const options: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'short' }
+        const fromDate = new Date(from.includes('-') ? from : parseInt(from)) // Handle YYYY-Mon and YYYY formats
+        const formattedFrom = fromDate.toLocaleDateString('en-US', options)
+
+        if (!to || to.toLowerCase() === 'present' || to === '') {
+            return `${formattedFrom} - Present`
+        }
+        const toDate = new Date(to.includes('-') ? to : parseInt(to))
+        const formattedTo = toDate.toLocaleDateString('en-US', options)
+        return `${formattedFrom} - ${formattedTo}`
+    }
+
+    return (
+        <Box sx={{ paddingY: 4, paddingX: 2 }}>
+            <Typography variant="h4" component="h2" gutterBottom sx={{ textAlign: 'center', marginBottom: 4 }}>
+                Professional Experience
+            </Typography>
+            <Timeline 
+                position="alternate" // Alternating timeline items left and right
+                sx={{
+                    [`& .${timelineItemClasses.root}:before`]: {
+                        flex: 0, // Remove the default line before the item for alternating timeline
+                        padding: 0,
+                    },
+                }}
+            >
+                {experience.map((item, index) => (
+                    <TimelineItem key={index}>
+                        <TimelineSeparator>
+                            <TimelineDot color="primary" />
+                            {index < experience.length - 1 && <TimelineConnector />}
+                        </TimelineSeparator>
+                        <TimelineContent sx={{ py: '12px', px: 2 }}>
+                            <Paper elevation={3} sx={{ p: 2 }}>
+                                <Typography variant="h6" component="span">
+                                    {item.position}
+                                </Typography>
+                                <Typography variant="subtitle1" color="textSecondary">
+                                    {item.company}
+                                </Typography>
+                                <Typography variant="body2" color="textSecondary" sx={{ my: 0.5 }}>
+                                    {formatDateRange(item.from, item.to)}
+                                </Typography>
+                                <Typography variant="caption" display="block" color="textSecondary" sx={{ mb: 1 }}>
+                                    {item.location}
+                                </Typography>
+                                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                                    {item.keySkills.map((skill, skillIndex) => (
+                                        <Chip key={skillIndex} label={skill} size="small" />
+                                    ))}
+                                </Box>
+                            </Paper>
+                        </TimelineContent>
+                    </TimelineItem>
+                ))}
+            </Timeline>
+        </Box>
+    )
+}
+
+export default ExperienceTimeline

--- a/app/component/modern-portfolio/footer.tsx
+++ b/app/component/modern-portfolio/footer.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import React from 'react'
+import { Box, Typography } from '@mui/material'
+
+interface FooterProps {
+    footer: {
+        year: number
+        companyName: string
+    }
+}
+
+const Footer: React.FC<FooterProps> = ({ footer }) => {
+    return (
+        <Box
+            component="footer" // Semantic HTML element
+            sx={{
+                py: 3, // Vertical padding
+                px: 2, // Horizontal padding
+                mt: 'auto', // Push footer to the bottom if content is short
+                backgroundColor: (theme) =>
+                    theme.palette.mode === 'dark'
+                        ? theme.palette.grey[800]
+                        : theme.palette.grey[200],
+                textAlign: 'center',
+            }}
+        >
+            <Typography variant="body2" color="text.secondary">
+                © {footer.year} {footer.companyName}. All Rights Reserved.
+            </Typography>
+        </Box>
+    )
+}
+
+export default Footer

--- a/app/component/modern-portfolio/heroSection.tsx
+++ b/app/component/modern-portfolio/heroSection.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import React from 'react'
+import { Box, Typography, Avatar, Button, Grid } from '@mui/material'
+
+interface HeroSectionProps {
+    name: string
+    title: string
+    bio: string
+    profileImage: string
+    onSeeProjectsClick: () => void
+    onContactMeClick: () => void
+}
+
+const HeroSection: React.FC<HeroSectionProps> = ({
+    name,
+    title,
+    bio,
+    profileImage,
+    onSeeProjectsClick,
+    onContactMeClick,
+}) => {
+    return (
+        <Box
+            sx={{
+                minHeight: '100vh',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                textAlign: 'center',
+                padding: 3, // Add some padding
+            }}
+        >
+            <Grid container spacing={4} direction="column" alignItems="center">
+                <Grid item>
+                    <Avatar
+                        alt={name}
+                        src={profileImage}
+                        sx={{
+                            width: 150,
+                            height: 150,
+                            margin: '0 auto 20px auto', // Center avatar and add bottom margin
+                        }}
+                    />
+                </Grid>
+                <Grid item>
+                    <Typography variant="h2" component="h1" gutterBottom>
+                        {name}
+                    </Typography>
+                </Grid>
+                <Grid item>
+                    <Typography variant="h5" color="textSecondary" gutterBottom>
+                        {title}
+                    </Typography>
+                </Grid>
+                <Grid item sx={{ maxWidth: '600px' }}> 
+                    <Typography variant="body1" paragraph sx={{ whiteSpace: 'pre-line' }}>
+                        {bio}
+                    </Typography>
+                </Grid>
+                <Grid item container spacing={2} justifyContent="center">
+                    <Grid item>
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            size="large"
+                            onClick={onSeeProjectsClick}
+                        >
+                            See Projects
+                        </Button>
+                    </Grid>
+                    <Grid item>
+                        <Button
+                            variant="outlined"
+                            color="primary"
+                            size="large"
+                            onClick={onContactMeClick}
+                        >
+                            Contact Me
+                        </Button>
+                    </Grid>
+                </Grid>
+            </Grid>
+        </Box>
+    )
+}
+
+export default HeroSection

--- a/app/component/modern-portfolio/projectsGrid.tsx
+++ b/app/component/modern-portfolio/projectsGrid.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import React from 'react'
+import {
+    Box,
+    Typography,
+    Grid,
+    Card,
+    CardContent,
+    CardActions,
+    Button,
+    Chip,
+    Link as MuiLink, // Renaming to avoid conflict with Next.js Link if used elsewhere
+} from '@mui/material'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'; // For the link button
+
+interface ProjectItem {
+    name: string
+    description: string
+    link: string
+    public: boolean
+}
+
+interface ProjectsGridProps {
+    projects: ProjectItem[]
+}
+
+const ProjectsGrid: React.FC<ProjectsGridProps> = ({ projects }) => {
+    return (
+        <Box sx={{ paddingY: 4, paddingX: 2 }}>
+            <Typography variant="h4" component="h2" gutterBottom sx={{ textAlign: 'center', marginBottom: 4 }}>
+                Projects
+            </Typography>
+            <Grid container spacing={3}>
+                {projects.map((project, index) => (
+                    <Grid item xs={12} sm={6} md={4} key={index}> {/* Responsive grid settings */}
+                        <Card sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+                            <CardContent sx={{ flexGrow: 1 }}>
+                                <Typography variant="h6" component="div" gutterBottom>
+                                    {project.name}
+                                </Typography>
+                                <Typography variant="body2" color="text.secondary">
+                                    {project.description}
+                                </Typography>
+                            </CardContent>
+                            <CardActions sx={{ padding: 2, justifyContent: 'space-between' }}>
+                                {project.link && (
+                                    <Button
+                                        variant="contained"
+                                        color="primary"
+                                        href={project.link}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        startIcon={<OpenInNewIcon />}
+                                        size="small"
+                                    >
+                                        View Project
+                                    </Button>
+                                )}
+                                {project.public && (
+                                    <Chip label="Live" color="success" size="small" />
+                                )}
+                            </CardActions>
+                        </Card>
+                    </Grid>
+                ))}
+            </Grid>
+        </Box>
+    )
+}
+
+export default ProjectsGrid

--- a/app/component/modern-portfolio/skillsDisplay.tsx
+++ b/app/component/modern-portfolio/skillsDisplay.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import React from 'react'
+import { Box, Typography, Chip, LinearProgress, Paper } from '@mui/material'
+
+interface SkillItem {
+    language: string
+    year: number
+}
+
+interface SkillsDisplayProps {
+    techStack: SkillItem[]
+}
+
+const MAX_EXPERIENCE_YEARS = 10 // Assuming 10 years is the max for 100% progress
+
+const SkillsDisplay: React.FC<SkillsDisplayProps> = ({ techStack }) => {
+    return (
+        <Box sx={{ paddingY: 4, paddingX: 2 }}>
+            <Typography variant="h4" component="h2" gutterBottom sx={{ textAlign: 'center', marginBottom: 4 }}>
+                Tech Stack
+            </Typography>
+            <Box
+                sx={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    overflowX: 'auto',
+                    paddingY: 2,
+                    '&::-webkit-scrollbar': {
+                        height: '8px',
+                    },
+                    '&::-webkit-scrollbar-thumb': {
+                        backgroundColor: 'rgba(0,0,0,0.2)',
+                        borderRadius: '4px',
+                    },
+                }}
+            >
+                {techStack.map((skill, index) => (
+                    <Paper
+                        key={index}
+                        elevation={3}
+                        sx={{
+                            minWidth: 200, // Ensure items have a minimum width so they don't get too squeezed
+                            padding: 2,
+                            marginRight: 2,
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: 'center',
+                            backgroundColor: (theme) => theme.palette.mode === 'dark' ? theme.palette.grey[800] : theme.palette.grey[100],
+                        }}
+                    >
+                        <Chip
+                            label={skill.language}
+                            color="primary"
+                            sx={{ marginBottom: 1, fontWeight: 'bold' }}
+                        />
+                        <Typography variant="body2" sx={{ marginBottom: 0.5 }}>
+                            {skill.year} {skill.year === 1 ? 'year' : 'years'}
+                        </Typography>
+                        <Box sx={{ width: '80%', marginTop: 1 }}>
+                            <LinearProgress
+                                variant="determinate"
+                                value={(skill.year / MAX_EXPERIENCE_YEARS) * 100}
+                                sx={{ height: 8, borderRadius: 4 }}
+                            />
+                        </Box>
+                    </Paper>
+                ))}
+            </Box>
+        </Box>
+    )
+}
+
+export default SkillsDisplay

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
+import Link from 'next/link'
+import { Box, AppBar, Toolbar, Button, Typography } from '@mui/material'
 import './globals.css'
 
 const inter = Inter({ subsets: ['latin'] })
@@ -16,7 +18,26 @@ export default function RootLayout({
 }>) {
     return (
         <html lang="en">
-            <body className={inter.className}>{children}</body>
+            <body className={inter.className}>
+                <AppBar position="static" sx={{ marginBottom: 2 }}>
+                    <Toolbar>
+                        <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+                            <Link href="/" passHref style={{ textDecoration: 'none', color: 'inherit' }}>
+                                My Portfolio
+                            </Link>
+                        </Typography>
+                        <Link href="/" passHref>
+                            <Button color="inherit">Original Design</Button>
+                        </Link>
+                        <Link href="/modern-portfolio" passHref>
+                            <Button color="inherit">Modern Portfolio</Button>
+                        </Link>
+                    </Toolbar>
+                </AppBar>
+                <Box component="main"> {/* Add a main Box wrapper for children for better layout control if needed */}
+                    {children}
+                </Box>
+            </body>
         </html>
     )
 }

--- a/app/modern-portfolio/page.tsx
+++ b/app/modern-portfolio/page.tsx
@@ -1,0 +1,224 @@
+'use client'
+
+import React, { useState } from 'react'
+import { Box, IconButton, CssBaseline } from '@mui/material'
+import { createTheme, ThemeProvider } from '@mui/material/styles'
+import Brightness4Icon from '@mui/icons-material/Brightness4'
+import Brightness7Icon from '@mui/icons-material/Brightness7'
+import { motion } from 'framer-motion'
+
+// Import newly created components
+import HeroSection from '@/app/component/modern-portfolio/heroSection'
+import SkillsDisplay from '@/app/component/modern-portfolio/skillsDisplay'
+import ExperienceTimeline from '@/app/component/modern-portfolio/experienceTimeline'
+import ProjectsGrid from '@/app/component/modern-portfolio/projectsGrid'
+import ContactBar from '@/app/component/modern-portfolio/contactBar'
+import Footer from '@/app/component/modern-portfolio/footer'
+
+// Imports for formValues data (icons, profileImage, FormValues type)
+import LinkedInIcon from '@mui/icons-material/LinkedIn'
+import ChatIcon from '@mui/icons-material/WhatsApp'
+import EmailIcon from '@mui/icons-material/Email'
+import profileImage from '@/public/static/me.jpg'
+import { FormValues } from '@/app/state/initialState'
+
+// Copied formValues object from pages/index.tsx (or the original version in this file)
+const formValues: FormValues = {
+    userInfo: {
+        name: 'Ajay GB',
+        title: 'Software Engineer',
+        bio: `> MERN stack & full-stack development
+> CI/CD pipelines & Microsoft Azure Cloud deployments
+> Passionate about microservices architecture / distributed architecture
+> Committed to continuous learning & collaboration `,
+    },
+    isTechStack: true,
+    techStack: [
+        { language: 'Java', year: 3 },
+        { language: 'Python', year: 4 },
+        { language: 'Angular', year: 2 },
+        { language: 'TypeScript', year: 2 },
+        { language: 'React', year: 3 },
+        { language: 'Node.js', year: 3 },
+        { language: 'CI/CD Pipelines', year: 3 },
+        { language: 'Azure Cloud', year: 3 },
+        { language: 'SpringBoot', year: 2 },
+        { language: 'Unix', year: 5 },
+        { language: 'Aws Cloud', year: 2 },
+    ],
+    isExperience: true,
+    experience: [
+        {
+            from: '2021-Feb',
+            to: '', // Present
+            company: 'Lithia / Pfaff Motors Inc',
+            location: 'Toronto',
+            position: 'Software Developer',
+            keySkills: ['Python', 'React', 'CI/CD', 'ExpressJs', 'MySql', 'Azure Cloud/Devops'],
+        },
+        {
+            from: '2019-May',
+            to: '2021-Feb',
+            company: 'Insyght AI',
+            location: 'Toronto, ON',
+            position: 'Intern + Full Stack Developer',
+            keySkills: ['Python', '.Net', 'Angular', 'Springboot', 'REST APIs'],
+        },
+        {
+            from: '2016-Jan',
+            to: '2018-Feb',
+            company: 'Infosys Limited',
+            location: 'Chennai, India',
+            position: 'Intern + Systems Engineer',
+            keySkills: ['Java', 'Spring Boot', 'Microservices', 'Unix'],
+        },
+    ],
+    isContact: true,
+    contact: [
+        { app: 'LinkedIn', icon: <LinkedInIcon />, link: 'https://www.linkedin.com/in/ajay-vigneshwar-gb-b3b665179/' },
+        { app: 'Whatsapp', icon: <ChatIcon />, link: 'https://wa.me/+12269758056' },
+        { app: 'Email', icon: <EmailIcon />, link: 'mailto:ajaygb7@gmail.com' },
+    ],
+    isProject: true,
+    projects: [
+        { name: 'MediDash', description: 'A comprehensive medical dashboard built using Next.js and Material-UI, featuring patient management, medical records, lab results, and appointment scheduling.', link: '/medical', public: false },
+        { name: 'Portfolio Website', description: 'Built using Next.js and Material-UI / Randomize user info', link: '/portfolio', public: false },
+        { name: 'Loan Calculator App', description: 'Built using Next.js, Material-UI, Chart.js / Calculate loan amortization', link: '/snow', public: false },
+        { name: 'Pdf Tool', description: 'Built using Next.js, Material-UI, pdf-lib / Merge, split, and edit PDF files', link: 'https://pdflab.app', public: true },
+    ],
+    isUseUserInfo: true,
+    isBadge: false,
+    profileImage: profileImage?.src || '/static/default-avatar.png',
+    footer: { year: new Date().getFullYear(), companyName: 'Ajay GB' },
+}
+
+// Define light and dark themes
+const lightTheme = createTheme({
+    palette: {
+        mode: 'light',
+        primary: { main: '#1976d2' }, // Blue
+        secondary: { main: '#dc004e' }, // Pink
+        background: { default: '#f4f6f8', paper: '#ffffff' },
+        text: { primary: '#333333' },
+    },
+    typography: {
+        fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+        h1: { fontWeight: 700 },
+        h2: { fontWeight: 600 },
+        h3: { fontWeight: 600 },
+        h4: { fontWeight: 500 },
+    },
+})
+
+const darkTheme = createTheme({
+    palette: {
+        mode: 'dark',
+        primary: { main: '#90caf9' }, // Lighter blue for dark mode
+        secondary: { main: '#f48fb1' }, // Lighter pink for dark mode
+        background: { default: '#121212', paper: '#1e1e1e' },
+        text: { primary: '#ffffff' },
+    },
+    typography: {
+        fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+        h1: { fontWeight: 700 },
+        h2: { fontWeight: 600 },
+        h3: { fontWeight: 600 },
+        h4: { fontWeight: 500 },
+    },
+})
+
+const sectionAnimation = {
+    initial: { opacity: 0, y: 30 },
+    animate: { opacity: 1, y: 0 },
+    transition: { duration: 0.7, ease: "easeOut" },
+}
+
+export default function ModernPortfolioPage() {
+    const [darkMode, setDarkMode] = useState(true) // Default to dark mode
+
+    const toggleTheme = () => {
+        setDarkMode(!darkMode)
+    }
+
+    const currentTheme = darkMode ? darkTheme : lightTheme
+
+    const handleScrollTo = (id: string) => {
+        const element = document.getElementById(id)
+        if (element) {
+            element.scrollIntoView({ behavior: 'smooth' })
+        }
+    }
+
+    const onSeeProjectsClick = () => handleScrollTo('projects-section')
+    const onContactMeClick = () => handleScrollTo('contact-section')
+
+    return (
+        <ThemeProvider theme={currentTheme}>
+            <CssBaseline /> {/* Ensures consistent baseline styling */}
+            <Box
+                sx={{
+                    minHeight: '100vh',
+                    backgroundColor: currentTheme.palette.background.default,
+                    color: currentTheme.palette.text.primary,
+                    display: 'flex',
+                    flexDirection: 'column', // Ensure footer is at the bottom
+                }}
+            >
+                <IconButton
+                    onClick={toggleTheme}
+                    color="inherit"
+                    sx={{
+                        position: 'fixed',
+                        top: 16,
+                        right: 16,
+                        zIndex: 1300, // Ensure it's above other content
+                        backgroundColor: currentTheme.palette.background.paper,
+                        '&:hover': {
+                             backgroundColor: currentTheme.palette.action.hover,
+                        }
+                    }}
+                >
+                    {darkMode ? <Brightness7Icon /> : <Brightness4Icon />}
+                </IconButton>
+
+                <motion.div {...sectionAnimation}>
+                    <HeroSection
+                        name={formValues.userInfo.name}
+                        title={formValues.userInfo.title}
+                        bio={formValues.userInfo.bio}
+                        profileImage={formValues.profileImage as string}
+                        onSeeProjectsClick={onSeeProjectsClick}
+                        onContactMeClick={onContactMeClick}
+                    />
+                </motion.div>
+
+                {formValues.isTechStack && formValues.techStack.length > 0 && (
+                    <motion.div {...sectionAnimation}>
+                        <SkillsDisplay techStack={formValues.techStack} />
+                    </motion.div>
+                )}
+
+                {formValues.isExperience && formValues.experience.length > 0 && (
+                    <motion.div {...sectionAnimation}>
+                        <ExperienceTimeline experience={formValues.experience} />
+                    </motion.div>
+                )}
+
+                {formValues.isProject && formValues.projects.length > 0 && (
+                     <motion.div {...sectionAnimation} id="projects-section">
+                        <ProjectsGrid projects={formValues.projects} />
+                    </motion.div>
+                )}
+
+                {formValues.isContact && formValues.contact.length > 0 && (
+                    <motion.div {...sectionAnimation} id="contact-section">
+                        <ContactBar contact={formValues.contact} />
+                    </motion.div>
+                )}
+                
+                {/* Footer should not be animated like other sections and should be outside the main flow of animated divs if it's meant to be always visible or transition differently */}
+                <Footer footer={formValues.footer} />
+            </Box>
+        </ThemeProvider>
+    )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
                 "dayjs": "^1.11.10",
                 "firebase": "^10.10.0",
                 "formidable": "^3.5.2",
+                "framer-motion": "^12.12.1",
                 "googleapis": "^144.0.0",
                 "mapbox-gl": "^3.8.0",
                 "next": "14.1.0",
@@ -915,20 +916,20 @@
             "integrity": "sha512-jmEnr/pk0yVkA7mIlHNnxCi+wWzOFUg0WyIotgkKAb2u1J7fAeDBcVNSTjTihbAYNusCLQdW5s9IJ5qwnEufcQ=="
         },
         "node_modules/@floating-ui/core": {
-            "version": "1.6.8",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
-            "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.0.tgz",
+            "integrity": "sha512-FRdBLykrPPA6P76GGGqlex/e7fbe0F1ykgxHYNXQsH/iTEtjMj/f9bpY5oQqbjt5VgZvgz/uKXbGuROijh3VLA==",
             "dependencies": {
-                "@floating-ui/utils": "^0.2.8"
+                "@floating-ui/utils": "^0.2.9"
             }
         },
         "node_modules/@floating-ui/dom": {
-            "version": "1.6.12",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.12.tgz",
-            "integrity": "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.0.tgz",
+            "integrity": "sha512-lGTor4VlXcesUMh1cupTUTDoCxMb0V6bm3CnxHzQcw8Eaf1jQbgQX4i02fYgT0vJ82tb5MZ4CZk1LRGkktJCzg==",
             "dependencies": {
-                "@floating-ui/core": "^1.6.0",
-                "@floating-ui/utils": "^0.2.8"
+                "@floating-ui/core": "^1.7.0",
+                "@floating-ui/utils": "^0.2.9"
             }
         },
         "node_modules/@floating-ui/react-dom": {
@@ -944,9 +945,9 @@
             }
         },
         "node_modules/@floating-ui/utils": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
-            "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+            "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
         },
         "node_modules/@grpc/grpc-js": {
             "version": "1.9.15",
@@ -1235,14 +1236,15 @@
             }
         },
         "node_modules/@mui/base": {
-            "version": "5.0.0-beta.40",
-            "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.40.tgz",
-            "integrity": "sha512-I/lGHztkCzvwlXpjD2+SNmvNQvB4227xBXhISPjEaJUXGImOQ9f3D2Yj/T3KasSI/h0MLWy74X0J6clhPmsRbQ==",
+            "version": "5.0.0-beta.40-1",
+            "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.40-1.tgz",
+            "integrity": "sha512-agKXuNNy0bHUmeU7pNmoZwNFr7Hiyhojkb9+2PVyDG5+6RafYuyMgbrav8CndsB7KUc/U51JAw9vKNDLYBzaUA==",
+            "deprecated": "This package has been replaced by @base-ui-components/react",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
                 "@floating-ui/react-dom": "^2.0.8",
-                "@mui/types": "^7.2.14",
-                "@mui/utils": "^5.15.14",
+                "@mui/types": "~7.2.15",
+                "@mui/utils": "^5.17.1",
                 "@popperjs/core": "^2.11.8",
                 "clsx": "^2.1.0",
                 "prop-types": "^15.8.1"
@@ -1255,9 +1257,9 @@
                 "url": "https://opencollective.com/mui-org"
             },
             "peerDependencies": {
-                "@types/react": "^17.0.0 || ^18.0.0",
-                "react": "^17.0.0 || ^18.0.0",
-                "react-dom": "^17.0.0 || ^18.0.0"
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
             },
             "peerDependenciesMeta": {
                 "@types/react": {
@@ -1300,15 +1302,15 @@
             }
         },
         "node_modules/@mui/lab": {
-            "version": "5.0.0-alpha.174",
-            "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.174.tgz",
-            "integrity": "sha512-6jw+vcjfnDr/V4qzqwOPFwoqzxejGfm9F0k9E92QLmtFv5F0pH73OjmQDzALL7zrcwR4iV4D94iJZ1xFawiREA==",
+            "version": "5.0.0-alpha.176",
+            "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.176.tgz",
+            "integrity": "sha512-DcZt1BAz4CDMUFGUvKqRh6W0sehmPj5luVHPx4vzSNnXj8xFvOdHwvNZ0bzNXy/Ol+81bkxcHQoIG2VOJuLnbw==",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
-                "@mui/base": "5.0.0-beta.40",
-                "@mui/system": "^5.16.8",
-                "@mui/types": "^7.2.15",
-                "@mui/utils": "^5.16.8",
+                "@mui/base": "5.0.0-beta.40-1",
+                "@mui/system": "^5.17.1",
+                "@mui/types": "~7.2.15",
+                "@mui/utils": "^5.17.1",
                 "clsx": "^2.1.0",
                 "prop-types": "^15.8.1"
             },
@@ -1389,12 +1391,12 @@
             "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g=="
         },
         "node_modules/@mui/private-theming": {
-            "version": "5.16.14",
-            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.16.14.tgz",
-            "integrity": "sha512-12t7NKzvYi819IO5IapW2BcR33wP/KAVrU8d7gLhGHoAmhDxyXlRoKiRij3TOD8+uzk0B6R9wHUNKi4baJcRNg==",
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.17.1.tgz",
+            "integrity": "sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
-                "@mui/utils": "^5.16.14",
+                "@mui/utils": "^5.17.1",
                 "prop-types": "^15.8.1"
             },
             "engines": {
@@ -1446,15 +1448,15 @@
             }
         },
         "node_modules/@mui/system": {
-            "version": "5.16.14",
-            "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.16.14.tgz",
-            "integrity": "sha512-KBxMwCb8mSIABnKvoGbvM33XHyT+sN0BzEBG+rsSc0lLQGzs7127KWkCA6/H8h6LZ00XpBEME5MAj8mZLiQ1tw==",
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.17.1.tgz",
+            "integrity": "sha512-aJrmGfQpyF0U4D4xYwA6ueVtQcEMebET43CUmKMP7e7iFh3sMIF3sBR0l8Urb4pqx1CBjHAaWgB0ojpND4Q3Jg==",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
-                "@mui/private-theming": "^5.16.14",
+                "@mui/private-theming": "^5.17.1",
                 "@mui/styled-engine": "^5.16.14",
-                "@mui/types": "^7.2.15",
-                "@mui/utils": "^5.16.14",
+                "@mui/types": "~7.2.15",
+                "@mui/utils": "^5.17.1",
                 "clsx": "^2.1.0",
                 "csstype": "^3.1.3",
                 "prop-types": "^15.8.1"
@@ -1498,12 +1500,12 @@
             }
         },
         "node_modules/@mui/utils": {
-            "version": "5.16.14",
-            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.16.14.tgz",
-            "integrity": "sha512-wn1QZkRzSmeXD1IguBVvJJHV3s6rxJrfb6YuC9Kk6Noh9f8Fb54nUs5JRkKm+BOerRhj5fLg05Dhx/H3Ofb8Mg==",
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.17.1.tgz",
+            "integrity": "sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
-                "@mui/types": "^7.2.15",
+                "@mui/types": "~7.2.15",
                 "@types/prop-types": "^15.7.12",
                 "clsx": "^2.1.1",
                 "prop-types": "^15.8.1",
@@ -4755,6 +4757,32 @@
                 "url": "https://github.com/sponsors/rawify"
             }
         },
+        "node_modules/framer-motion": {
+            "version": "12.12.1",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.12.1.tgz",
+            "integrity": "sha512-PFw4/GCREHI2suK/NlPSUxd+x6Rkp80uQsfCRFSOQNrm5pZif7eGtmG1VaD/UF1fW9tRBy5AaS77StatB3OJDg==",
+            "dependencies": {
+                "motion-dom": "^12.12.1",
+                "motion-utils": "^12.12.1",
+                "tslib": "^2.4.0"
+            },
+            "peerDependencies": {
+                "@emotion/is-prop-valid": "*",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/is-prop-valid": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "react-dom": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -6838,6 +6866,19 @@
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
+        },
+        "node_modules/motion-dom": {
+            "version": "12.12.1",
+            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.12.1.tgz",
+            "integrity": "sha512-GXq/uUbZBEiFFE+K1Z/sxdPdadMdfJ/jmBALDfIuHGi0NmtealLOfH9FqT+6aNPgVx8ilq0DtYmyQlo6Uj9LKQ==",
+            "dependencies": {
+                "motion-utils": "^12.12.1"
+            }
+        },
+        "node_modules/motion-utils": {
+            "version": "12.12.1",
+            "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.12.1.tgz",
+            "integrity": "sha512-f9qiqUHm7hWSLlNW8gS9pisnsN7CRFRD58vNjptKdsqFLpkVnX00TNeD6Q0d27V9KzT7ySFyK1TZ/DShfVOv6w=="
         },
         "node_modules/ms": {
             "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "dayjs": "^1.11.10",
         "firebase": "^10.10.0",
         "formidable": "^3.5.2",
+        "framer-motion": "^12.12.1",
         "googleapis": "^144.0.0",
         "mapbox-gl": "^3.8.0",
         "next": "14.1.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,6 +5,8 @@ import ChatIcon from '@mui/icons-material/WhatsApp'
 import EmailIcon from '@mui/icons-material/Email'
 import PortfolioDisplay from '@/app/component/portfolio/portfolioDisplay'
 import profileImage from '@/public/static/me.jpg'
+import Link from 'next/link'
+import { Box, Button } from '@mui/material'
 
 import { FormValues } from '@/app/state/initialState'
 
@@ -117,5 +119,16 @@ const formValues: FormValues = {
 }
 
 export default function Index() {
-    return <PortfolioDisplay formProps={formValues} />
+    return (
+        <>
+            <Box sx={{ textAlign: 'center', my: 2 }}>
+                <Link href="/modern-portfolio" passHref>
+                    <Button variant="contained" color="secondary">
+                        View New Modern Design
+                    </Button>
+                </Link>
+            </Box>
+            <PortfolioDisplay formProps={formValues} />
+        </>
+    )
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -122,11 +122,19 @@ export default function Index() {
     return (
         <>
             <Box sx={{ textAlign: 'center', my: 2 }}>
-                <Link href="/modern-portfolio" passHref>
-                    <Button variant="contained" color="secondary">
+                <a href="/modern-portfolio" style={{ textDecoration: 'none' }}>
+                    <button
+                        style={{
+                            padding: '10px 20px',
+                            backgroundColor: '#f50057',
+                            color: '#fff',
+                            border: 'none',
+                            borderRadius: '4px',
+                        }}
+                    >
                         View New Modern Design
-                    </Button>
-                </Link>
+                    </button>
+                </a>
             </Box>
             <PortfolioDisplay formProps={formValues} />
         </>

--- a/pages/modern-portfolio/index.tsx
+++ b/pages/modern-portfolio/index.tsx
@@ -54,7 +54,14 @@ const formValues: FormValues = {
             company: 'Lithia / Pfaff Motors Inc',
             location: 'Toronto',
             position: 'Software Developer',
-            keySkills: ['Python', 'React', 'CI/CD', 'ExpressJs', 'MySql', 'Azure Cloud/Devops'],
+            keySkills: [
+                'Python',
+                'React',
+                'CI/CD',
+                'ExpressJs',
+                'MySql',
+                'Azure Cloud/Devops',
+            ],
         },
         {
             from: '2019-May',
@@ -75,16 +82,48 @@ const formValues: FormValues = {
     ],
     isContact: true,
     contact: [
-        { app: 'LinkedIn', icon: <LinkedInIcon />, link: 'https://www.linkedin.com/in/ajay-vigneshwar-gb-b3b665179/' },
-        { app: 'Whatsapp', icon: <ChatIcon />, link: 'https://wa.me/+12269758056' },
+        {
+            app: 'LinkedIn',
+            icon: <LinkedInIcon />,
+            link: 'https://www.linkedin.com/in/ajay-vigneshwar-gb-b3b665179/',
+        },
+        {
+            app: 'Whatsapp',
+            icon: <ChatIcon />,
+            link: 'https://wa.me/+12269758056',
+        },
         { app: 'Email', icon: <EmailIcon />, link: 'mailto:ajaygb7@gmail.com' },
     ],
     isProject: true,
     projects: [
-        { name: 'MediDash', description: 'A comprehensive medical dashboard built using Next.js and Material-UI, featuring patient management, medical records, lab results, and appointment scheduling.', link: '/medical', public: false },
-        { name: 'Portfolio Website', description: 'Built using Next.js and Material-UI / Randomize user info', link: '/portfolio', public: false },
-        { name: 'Loan Calculator App', description: 'Built using Next.js, Material-UI, Chart.js / Calculate loan amortization', link: '/snow', public: false },
-        { name: 'Pdf Tool', description: 'Built using Next.js, Material-UI, pdf-lib / Merge, split, and edit PDF files', link: 'https://pdflab.app', public: true },
+        {
+            name: 'MediDash',
+            description:
+                'A comprehensive medical dashboard built using Next.js and Material-UI, featuring patient management, medical records, lab results, and appointment scheduling.',
+            link: '/medical',
+            public: false,
+        },
+        {
+            name: 'Portfolio Website',
+            description:
+                'Built using Next.js and Material-UI / Randomize user info',
+            link: '/portfolio',
+            public: false,
+        },
+        {
+            name: 'Loan Calculator App',
+            description:
+                'Built using Next.js, Material-UI, Chart.js / Calculate loan amortization',
+            link: '/snow',
+            public: false,
+        },
+        {
+            name: 'Pdf Tool',
+            description:
+                'Built using Next.js, Material-UI, pdf-lib / Merge, split, and edit PDF files',
+            link: 'https://pdflab.app',
+            public: true,
+        },
     ],
     isUseUserInfo: true,
     isBadge: false,
@@ -130,7 +169,7 @@ const darkTheme = createTheme({
 const sectionAnimation = {
     initial: { opacity: 0, y: 30 },
     animate: { opacity: 1, y: 0 },
-    transition: { duration: 0.7, ease: "easeOut" },
+    transition: { duration: 0.7, ease: 'easeOut' },
 }
 
 export default function ModernPortfolioPage() {
@@ -174,8 +213,8 @@ export default function ModernPortfolioPage() {
                         zIndex: 1300, // Ensure it's above other content
                         backgroundColor: currentTheme.palette.background.paper,
                         '&:hover': {
-                             backgroundColor: currentTheme.palette.action.hover,
-                        }
+                            backgroundColor: currentTheme.palette.action.hover,
+                        },
                     }}
                 >
                     {darkMode ? <Brightness7Icon /> : <Brightness4Icon />}
@@ -198,14 +237,17 @@ export default function ModernPortfolioPage() {
                     </motion.div>
                 )}
 
-                {formValues.isExperience && formValues.experience.length > 0 && (
-                    <motion.div {...sectionAnimation}>
-                        <ExperienceTimeline experience={formValues.experience} />
-                    </motion.div>
-                )}
+                {formValues.isExperience &&
+                    formValues.experience.length > 0 && (
+                        <motion.div {...sectionAnimation}>
+                            <ExperienceTimeline
+                                experience={formValues.experience}
+                            />
+                        </motion.div>
+                    )}
 
                 {formValues.isProject && formValues.projects.length > 0 && (
-                     <motion.div {...sectionAnimation} id="projects-section">
+                    <motion.div {...sectionAnimation} id="projects-section">
                         <ProjectsGrid projects={formValues.projects} />
                     </motion.div>
                 )}
@@ -215,7 +257,7 @@ export default function ModernPortfolioPage() {
                         <ContactBar contact={formValues.contact} />
                     </motion.div>
                 )}
-                
+
                 {/* Footer should not be animated like other sections and should be outside the main flow of animated divs if it's meant to be always visible or transition differently */}
                 <Footer footer={formValues.footer} />
             </Box>


### PR DESCRIPTION
This commit introduces a new, modern portfolio page design as an alternative to the existing one.

Key features:
- New page route: `/modern-portfolio`
- Modular components for each section: Hero, Skills, Experience, Projects, Contact, Footer.
- Implemented using Next.js App Router and Material-UI.
- Data is sourced from the `formValues` object.
- Includes light/dark mode theme toggle.
- Basic fade-in animations using Framer Motion for sections.
- Responsive design for desktop, tablet, and mobile.
- Scroll-to-section functionality for "See Projects" and "Contact Me" buttons.
- Global navigation added in `app/layout.tsx` to switch between old and new designs.
- Link added on the original portfolio page to the new design for discoverability.

All new components are located under `app/component/modern-portfolio/`. The new page is `app/modern-portfolio/page.tsx`.
The `@mui/lab` package was added for the Timeline component.