### PR TITLE
fix: Correct duplicate function definition in AstronautModel

### DIFF
--- a/app/component/3d-portfolio/AstronautModel.tsx
+++ b/app/component/3d-portfolio/AstronautModel.tsx
@@ -67,13 +67,6 @@ const AstronautModel: React.FC<AstronautModelProps> = ({ name, onToggleBio }) =>
   };
   
   const handleCloseEasterEggModal = () => {
-    if (newClickCount === 3) {
-      setShowEasterEggModal(true);
-      setClickCount(0);
-    }
-  };
-  
-  const handleCloseEasterEggModal = () => {
     setShowEasterEggModal(false);
   };
 


### PR DESCRIPTION
This commit removes a duplicate definition of the \`handleCloseEasterEggModal\` function within the \`AstronautModel.tsx\` component. This error was causing the build to fail. The remaining definition correctly handles the closing of the easter egg modal.