### PR TITLE
Add Monaco track with orbiting boxes

### DIFF
--- a/pages/f1.tsx
+++ b/pages/f1.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Canvas, useFrame } from '@react-three/fiber'
-import { OrbitControls, Text, Box, Plane, Torus } from '@react-three/drei'
+import { OrbitControls, Text, Box, Plane } from '@react-three/drei'
 import React, { useRef } from 'react'
 import * as THREE from 'three'
 import f1Data from '@/public/data/f1.json'
@@ -41,11 +41,103 @@ const Car = ({ color, number, name, trackRadius, angleOffset }: CarProps) => {
   )
 }
 
-const Track = () => (
-  <Torus args={[4, 0.2, 16, 100]} rotation={[-Math.PI / 2, 0, 0]}>
-    <meshStandardMaterial color="gray" />
-  </Torus>
-)
+const monacoPath = [
+  new THREE.Vector2(4, 0),
+  new THREE.Vector2(3, 1),
+  new THREE.Vector2(2.5, 1.2),
+  new THREE.Vector2(1.5, 2),
+  new THREE.Vector2(1, 3),
+  new THREE.Vector2(0, 3.5),
+  new THREE.Vector2(-1, 3.4),
+  new THREE.Vector2(-2, 3),
+  new THREE.Vector2(-3, 2),
+  new THREE.Vector2(-3.8, 1),
+  new THREE.Vector2(-4, 0),
+  new THREE.Vector2(-3.8, -1),
+  new THREE.Vector2(-3, -2),
+  new THREE.Vector2(-2, -2.8),
+  new THREE.Vector2(-1, -3.4),
+  new THREE.Vector2(0, -3.5),
+  new THREE.Vector2(1, -3.2),
+  new THREE.Vector2(2, -2.5),
+  new THREE.Vector2(3, -1.5),
+  new THREE.Vector2(3.8, -0.5),
+]
+
+const Track = () => {
+  const shape = React.useMemo(() => {
+    const outer = new THREE.Shape()
+    outer.moveTo(monacoPath[0].x, monacoPath[0].y)
+    monacoPath.slice(1).forEach(p => outer.lineTo(p.x, p.y))
+    outer.lineTo(monacoPath[0].x, monacoPath[0].y)
+
+    const inner = new THREE.Path()
+    const shrink = 0.9
+    inner.moveTo(monacoPath[0].x * shrink, monacoPath[0].y * shrink)
+    monacoPath.slice(1).forEach(p => inner.lineTo(p.x * shrink, p.y * shrink))
+    inner.lineTo(monacoPath[0].x * shrink, monacoPath[0].y * shrink)
+    outer.holes.push(inner)
+    return outer
+  }, [])
+
+  const geometry = React.useMemo(() => {
+    const geo = new THREE.ExtrudeGeometry(shape, {
+      depth: 0.2,
+      bevelEnabled: false,
+    })
+    geo.rotateX(-Math.PI / 2)
+    geo.computeVertexNormals()
+    return geo
+  }, [shape])
+
+  const stripeTexture = React.useMemo(() => {
+    const size = 64
+    const canvas = document.createElement('canvas')
+    canvas.width = size
+    canvas.height = size
+    const ctx = canvas.getContext('2d')!
+    ctx.fillStyle = '#ff0000'
+    ctx.fillRect(0, 0, size / 2, size)
+    ctx.fillStyle = '#ffffff'
+    ctx.fillRect(size / 2, 0, size / 2, size)
+    const tex = new THREE.CanvasTexture(canvas)
+    tex.wrapS = tex.wrapT = THREE.RepeatWrapping
+    tex.repeat.set(40, 1)
+    return tex
+  }, [])
+
+  const materials = React.useMemo(
+    () => [
+      new THREE.MeshStandardMaterial({ color: '#333333' }),
+      new THREE.MeshStandardMaterial({ color: '#333333' }),
+      new THREE.MeshStandardMaterial({ map: stripeTexture }),
+    ],
+    [stripeTexture]
+  )
+
+  return (
+    <mesh geometry={geometry} material={materials} position={[0, 0.05, 0]} castShadow receiveShadow />
+  )
+}
+
+const OrbitingBox = ({ color, offset }: { color: string; offset: number }) => {
+  const ref = useRef<THREE.Mesh>(null!)
+  useFrame(({ clock }) => {
+    const t = clock.getElapsedTime() * 0.3 + offset
+    const radius = 4
+    const x = radius * Math.cos(t)
+    const z = radius * Math.sin(t)
+    if (ref.current) {
+      ref.current.position.set(x, 1.5, z)
+      ref.current.rotation.y = -t + Math.PI / 2
+    }
+  })
+  return (
+    <Box ref={ref} args={[0.3, 0.3, 0.3]} castShadow>
+      <meshStandardMaterial color={color} />
+    </Box>
+  )
+}
 
 export default function F1Scene() {
   return (
@@ -57,6 +149,13 @@ export default function F1Scene() {
           <meshStandardMaterial color="black" />
         </Plane>
         <Track />
+        {[
+          { color: 'orange', offset: 0 },
+          { color: 'green', offset: (2 * Math.PI) / 3 },
+          { color: 'blue', offset: (4 * Math.PI) / 3 },
+        ].map((b, i) => (
+          <OrbitingBox key={i} color={b.color} offset={b.offset} />
+        ))}
         {f1Data.map((driver, idx) => (
           <Car
             key={idx}


### PR DESCRIPTION
## Summary
- replace torus with an extruded Monaco-style track using custom Vector2 path
- add striped kerbs and orbiting marker boxes around the track
- keep existing cars and lighting untouched

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68485929543883238c56e0e2fec184b3