### PR TITLE
Integrate MovingCar component for F1 scene

### DIFF
--- a/app/component/f1/MovingCar.tsx
+++ b/app/component/f1/MovingCar.tsx
@@ -1,0 +1,55 @@
+import { useGLTF } from '@react-three/drei'
+import { useFrame } from '@react-three/fiber'
+import React, { useRef } from 'react' // Added React import
+import * as THREE from 'three'
+
+interface MovingCarProps {
+  modelUrl: string
+  initialT: number
+  trackPathCurve: THREE.CatmullRomCurve3
+  speed?: number
+}
+
+export function MovingCar({
+  modelUrl,
+  initialT,
+  trackPathCurve,
+  speed = 0.1
+}: MovingCarProps) {
+  const gltf = useGLTF(modelUrl) as any
+  const ref = useRef<THREE.Group>(null!)
+  // The track's top surface is at y = 0.05 (group elevation) + 0.2 (track thickness) = 0.25.
+  // The car is scaled by 0.2.
+  // fixedY = 0.3 implies the car's center is 0.05 units above the track surface.
+  // This means the car's scaled height from its pivot point to its top + bottom is 0.1.
+  const fixedY = 0.15 + 0.3 / 2 // This equals 0.3
+
+  useFrame(({ clock }) => {
+    if (!trackPathCurve || !ref.current) return; // Added check for ref.current
+
+    const t = (clock.getElapsedTime() * speed + initialT) % 1
+    const p = trackPathCurve.getPointAt(t)
+    const tan = trackPathCurve.getTangentAt(t)
+
+    // world-space mapping
+    // p.x and p.y are from the track curve (originally 2D, mapped to XZ plane by track rotation)
+    // fixedY is the world Y coordinate
+    ref.current.position.set(p.x, fixedY, p.y)
+    ref.current.lookAt(p.x + tan.x, fixedY, p.y + tan.y)
+  })
+
+  return (
+    <primitive
+      ref={ref}
+      object={gltf.scene}
+      scale={0.2}            // tweak so car sits nicely on 0.8-wide track
+      castShadow
+      receiveShadow
+    />
+  )
+}
+
+// Preload the model (optional, but good practice)
+// useGLTF.preload(modelUrl) // This line would cause an error here because modelUrl is a prop
+// If preloading is desired for specific models, it should be done where modelUrl is static,
+// e.g., in the parent component or by passing a statically known URL here if appropriate.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@mui/material": "^5.16.14",
                 "@mui/x-date-pickers": "^7.1.0",
                 "@react-oauth/google": "^0.12.1",
-                "@react-three/drei": "^9.121.5",
+                "@react-three/drei": "^9.122.0",
                 "@react-three/fiber": "^8.18.0",
                 "@tomtom-international/web-sdk-maps": "^6.25.0",
                 "@tomtom-international/web-sdk-services": "^6.25.0",
@@ -3535,9 +3535,9 @@
             "integrity": "sha512-Fk1wYVAKL+ZTYK+4YFDpHf3Slsy59pfFFvnnTfRjQQFGlyIo4VejPtDs3CbDiuBjM135YztRyZjIH2VbycB+ZQ=="
         },
         "node_modules/@react-three/drei": {
-            "version": "9.121.5",
-            "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.121.5.tgz",
-            "integrity": "sha512-wApP8NMCvlLmL4DIZ1JEsLJY6FAZd86AO2082Dc7oonihnNzM/3YrshrNs+a+dLr9oeIlDk1AxBZx9I0CO99mg==",
+            "version": "9.122.0",
+            "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.122.0.tgz",
+            "integrity": "sha512-SEO/F/rBCTjlLez7WAlpys+iGe9hty4rNgjZvgkQeXFSiwqD4Hbk/wNHMAbdd8vprO2Aj81mihv4dF5bC7D0CA==",
             "dependencies": {
                 "@babel/runtime": "^7.26.0",
                 "@mediapipe/tasks-vision": "0.10.17",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "@mui/material": "^5.16.14",
         "@mui/x-date-pickers": "^7.1.0",
         "@react-oauth/google": "^0.12.1",
-        "@react-three/drei": "^9.121.5",
+        "@react-three/drei": "^9.122.0",
         "@react-three/fiber": "^8.18.0",
         "@tomtom-international/web-sdk-maps": "^6.25.0",
         "@tomtom-international/web-sdk-services": "^6.25.0",

--- a/pages/f1-monaco.tsx
+++ b/pages/f1-monaco.tsx
@@ -2,6 +2,7 @@
 
 import { Canvas, useFrame } from '@react-three/fiber'
 import { OrbitControls, Plane, Box } from '@react-three/drei' // Will add more imports later
+import { MovingCar } from '@/app/component/f1/MovingCar';
 import React, { useMemo, useRef, useEffect, useState } from 'react'
 import * as THREE from 'three'
 import { SVGLoader } from 'three/examples/jsm/loaders/SVGLoader.js';
@@ -65,59 +66,6 @@ const Track = ({ trackPathCurve }: TrackProps) => {
   // The shape's X-axis (rectWidth) is perpendicular to the path, forming the track width.
   return (
     <mesh geometry={trackGeometry} material={asphaltMaterial} rotation={[-Math.PI / 2, 0, 0]} castShadow receiveShadow />
-  );
-};
-
-// Placeholder for MovingBox component
-// const MovingBox = ({ color, angleOffset }) => { ... }
-
-interface MovingBoxProps {
-  boxColor: THREE.ColorRepresentation;
-  initialT: number; // Initial progress along the track (0 to 1)
-  trackPathCurve: THREE.CatmullRomCurve3 | null; // Can be null
-  speed?: number; // Speed multiplier for movement along the track
-}
-
-const MovingBox = ({ boxColor, initialT, trackPathCurve, speed = 0.1 }: MovingBoxProps) => {
-  const meshRef = useRef<THREE.Mesh>(null!);
-
-  // Elevated slightly more than track's potential rectHeight/2 + group elevation, to ensure it's visibly above.
-  // Track is at y=0.05, rectHeight = 0.2 (from Track component), so track surface top is at 0.05 + 0.1 = 0.15.
-  // Box height is 0.3, so its center should be at 0.15 + 0.3/2 = 0.3 for it to sit on the track.
-  const fixedYPosition = 0.15 + 0.3 / 2;
-
-
-  useFrame(({ clock }) => {
-    if (!trackPathCurve || !meshRef.current) return; // Check inside useFrame
-
-    const elapsedTime = clock.getElapsedTime();
-    const t = (elapsedTime * speed + initialT) % 1; // Loop from 0 to 1
-
-    // if (meshRef.current && trackPathCurve) { // trackPathCurve is already checked
-      const positionOnCurve = trackPathCurve.getPointAt(t); // This is in XY plane of curve definition
-      const tangentToCurve = trackPathCurve.getTangentAt(t); // Also in XY plane
-
-      // Transform position and tangent from curve's XY plane to world's XZ plane
-      // Original curve point (x, y, 0) maps to world (x, fixedYPosition, y)
-      // due to track's rotation [-Math.PI / 2, 0, 0] which maps Y_curve -> Z_world, X_curve -> X_world.
-      meshRef.current.position.set(positionOnCurve.x, fixedYPosition, positionOnCurve.y);
-
-      // Orient the box
-      const lookAtPosition = new THREE.Vector3(
-        positionOnCurve.x + tangentToCurve.x,
-        fixedYPosition, // Keep Y level for lookAt to avoid tilting up/down
-        positionOnCurve.y + tangentToCurve.y
-      );
-      meshRef.current.lookAt(lookAtPosition);
-    // }
-  });
-
-  if (!trackPathCurve) return null; // Early return after all hooks
-
-  return (
-    <Box ref={meshRef} args={[0.3, 0.3, 0.3]} castShadow>
-      <meshStandardMaterial color={boxColor} />
-    </Box>
   );
 };
 
@@ -275,10 +223,31 @@ export default function F1MonacoScene() {
           {trackPathCurve && <Track trackPathCurve={trackPathCurve} />}
           {trackPathCurve && <StartFinishLine trackPathCurve={trackPathCurve} />}
         </group>
-        {/* Moving Boxes along the track */}
-        {trackPathCurve && <MovingBox boxColor="red" initialT={boxInitialProgress[0]} trackPathCurve={trackPathCurve} speed={0.05} />}
-        {trackPathCurve && <MovingBox boxColor="green" initialT={boxInitialProgress[1]} trackPathCurve={trackPathCurve} speed={0.05} />}
-        {trackPathCurve && <MovingBox boxColor="blue" initialT={boxInitialProgress[2]} trackPathCurve={trackPathCurve} speed={0.05} />}
+        {/* Moving Cars along the track */}
+        {trackPathCurve && (
+          <MovingCar
+            modelUrl="/models/pixel_f1_car.glb"
+            initialT={boxInitialProgress[0]}
+            trackPathCurve={trackPathCurve}
+            speed={0.05}
+          />
+        )}
+        {trackPathCurve && (
+          <MovingCar
+            modelUrl="/models/pixel_f1_car.glb"
+            initialT={boxInitialProgress[1]}
+            trackPathCurve={trackPathCurve}
+            speed={0.05}
+          />
+        )}
+        {trackPathCurve && (
+          <MovingCar
+            modelUrl="/models/pixel_f1_car.glb"
+            initialT={boxInitialProgress[2]}
+            trackPathCurve={trackPathCurve}
+            speed={0.05}
+          />
+        )}
         <OrbitControls />
       </Canvas>
     </div>


### PR DESCRIPTION
Replaces the MovingBox component in the f1-monaco scene with a new MovingCar component capable of loading and displaying a glTF 3D model.

Key changes:
- Added MovingCar.tsx component in app/component/f1/, which handles glTF model loading and animation along a track curve.
- Updated pages/f1-monaco.tsx to remove the old MovingBox definition and use the MovingCar component, pointing to "/models/pixel_f1_car.glb" for the model.
- Ensured necessary dependencies (three, @react-three/drei) are installed.
- Created the public/models/ directory to house the 3D model.

The MovingCar component is configured to position the car correctly on the track surface based on the track's elevation and the car's scale.