### PR TITLE
Feat: Update F1 placeholder visuals and add track line

### DIFF
--- a/app/component/f1/MovingCar.tsx
+++ b/app/component/f1/MovingCar.tsx
@@ -48,7 +48,7 @@ export function MovingCar({
   // Always render the fallback box
   return (
     <mesh ref={ref} scale={0.2} castShadow receiveShadow>
-      <boxGeometry args={[2, 0.5, 5]} />
+      <boxGeometry args={[0.5, 0.2, 1.0]} /> {/* Changed dimensions */}
       <meshStandardMaterial color="orange" />
     </mesh>
   );

--- a/pages/f1-monaco.tsx
+++ b/pages/f1-monaco.tsx
@@ -148,6 +148,30 @@ const StartFinishLine = ({ trackPathCurve }: StartFinishLineProps) => {
   return <mesh ref={meshRef} geometry={geometry} material={material} />;
 };
 
+interface TrackPathLineProps {
+  trackPathCurve: THREE.CatmullRomCurve3 | null;
+}
+
+const TrackPathLine: React.FC<TrackPathLineProps> = ({ trackPathCurve }) => {
+  const lineGeometry = useMemo(() => {
+    if (!trackPathCurve) return null;
+    const yLevelForLine = 0.28; // Slightly above track surface for visibility
+    // Get enough points for a smooth curve
+    const linePoints = trackPathCurve.getPoints(200).map(p => new THREE.Vector3(p.x, yLevelForLine, p.y));
+    return new THREE.BufferGeometry().setFromPoints(linePoints);
+  }, [trackPathCurve]);
+
+  const lineMaterial = useMemo(() => new THREE.LineBasicMaterial({
+    color: 0xffffff, // White color
+    // Note: linewidth > 1 might not work on all platforms/drivers with WebGL1
+    // For WebGL2 or specific extensions, it might. Otherwise, consider alternative ways for thicker lines if needed.
+  }), []);
+
+  if (!lineGeometry) return null;
+
+  return <primitive object={new THREE.Line(lineGeometry, lineMaterial)} />;
+};
+
 
 export default function F1MonacoScene() {
   const [svgTrackPoints, setSvgTrackPoints] = useState<THREE.Vector2[] | null>(null);
@@ -223,6 +247,8 @@ export default function F1MonacoScene() {
           {trackPathCurve && <Track trackPathCurve={trackPathCurve} />}
           {trackPathCurve && <StartFinishLine trackPathCurve={trackPathCurve} />}
         </group>
+        {/* Visual guide for the track path */}
+        {trackPathCurve && <TrackPathLine trackPathCurve={trackPathCurve} />}
         {/* Moving Cars along the track */}
         {trackPathCurve && (
           <MovingCar


### PR DESCRIPTION
This commit introduces several visual adjustments to the F1 monaco scene:

1.  **Reduced Box Size**: The placeholder boxes in `MovingCar.tsx` have been made smaller (args changed from `[2, 0.5, 5]` to `[0.5, 0.2, 1.0]` before scaling) for a "tinier" appearance.

2.  **Verified Orientation**: The existing `lookAt` logic in `MovingCar.tsx` for box orientation was reviewed and deemed correct for aligning the box with the track tangent. The new smaller, elongated box shape should aid in perceived orientation.

3.  **Added Track Path Visualization**: A new `TrackPathLine` component was added to `pages/f1-monaco.tsx`. This component renders a white line following the `trackPathCurve`, making the path of the moving boxes visible. The line is positioned slightly above the track surface.

Debug console logs previously added to `MovingCar.tsx` remain to help diagnose any further animation issues if they arise.