### PR TITLE
Fix: Adjust track guideline orientation

### DIFF
--- a/pages/f1-monaco.tsx
+++ b/pages/f1-monaco.tsx
@@ -155,9 +155,9 @@ interface TrackPathLineProps {
 const TrackPathLine: React.FC<TrackPathLineProps> = ({ trackPathCurve }) => {
   const lineGeometry = useMemo(() => {
     if (!trackPathCurve) return null;
-    const yLevelForLine = 0.28; // Slightly above track surface for visibility
-    // Get enough points for a smooth curve
-    const linePoints = trackPathCurve.getPoints(200).map(p => new THREE.Vector3(p.x, yLevelForLine, p.y));
+    const yLevelForLine = 0.28;
+    // Changed p.x, p.y mapping here
+    const linePoints = trackPathCurve.getPoints(200).map(p => new THREE.Vector3(p.y, yLevelForLine, p.x));
     return new THREE.BufferGeometry().setFromPoints(linePoints);
   }, [trackPathCurve]);
 


### PR DESCRIPTION
I modified the TrackPathLine component in pages/f1-monaco.tsx. The generation of 3D points for the guideline now maps the trackPathCurve's original p.y to world X and p.x to world Z (i.e., new THREE.Vector3(p.y, yLevelForLine, p.x)).

This change is intended to correct a reported issue where the guideline was perceived as being misaligned or "flipped" by 90 degrees relative to the visual track mesh. This alteration effectively rotates the guideline in the XZ plane.