### PR TITLE
Revert: Revert track guideline orientation adjustment

### DIFF
--- a/pages/f1-monaco.tsx
+++ b/pages/f1-monaco.tsx
@@ -156,8 +156,8 @@ const TrackPathLine: React.FC<TrackPathLineProps> = ({ trackPathCurve }) => {
   const lineGeometry = useMemo(() => {
     if (!trackPathCurve) return null;
     const yLevelForLine = 0.28;
-    // Changed p.x, p.y mapping here
-    const linePoints = trackPathCurve.getPoints(200).map(p => new THREE.Vector3(p.y, yLevelForLine, p.x));
+    // Reverted p.x, p.y mapping here
+    const linePoints = trackPathCurve.getPoints(200).map(p => new THREE.Vector3(p.x, yLevelForLine, p.y));
     return new THREE.BufferGeometry().setFromPoints(linePoints);
   }, [trackPathCurve]);
 


### PR DESCRIPTION
This commit reverts the changes made in the previous commit (branch: fix/trackline-orientation).

The TrackPathLine component in pages/f1-monaco.tsx has its 3D point generation for the guideline changed back to: `new THREE.Vector3(p.x, yLevelForLine, p.y)`
from:
`new THREE.Vector3(p.y, yLevelForLine, p.x)`

This is based on your feedback to revert the previous attempt to alter the line's orientation.