### PR TITLE
Fix: Improve speed constancy of moving boxes in F1 Monaco scene

### DIFF
--- a/app/component/f1/MovingCar.tsx
+++ b/app/component/f1/MovingCar.tsx
@@ -1,5 +1,5 @@
 import { useFrame } from '@react-three/fiber';
-import React, { useRef, useMemo, memo } from 'react'; // Removed useState, useEffect
+import React, { useRef, useMemo, memo, useEffect } from 'react'; // Removed useState, useEffect
 import * as THREE from 'three';
 
 interface MovingCarProps {
@@ -23,6 +23,13 @@ export const MovingCar = memo(function MovingCar({
   // useEffect(() => { ... }); // Removed GLTF error handling effect
 
   const fixedY = useMemo(() => 0.15 + 0.3 / 2, []);
+
+  useEffect(() => {
+    if (trackPathCurve) {
+      trackPathCurve.arcLengthDivisions = 300; // Increase divisions for potentially better accuracy
+      trackPathCurve.getLength(); // Pre-calculate and cache arc lengths
+    }
+  }, [trackPathCurve]);
 
   useFrame(({ clock }) => {
     if (!trackPathCurve || !ref.current) {


### PR DESCRIPTION
This commit enhances the `MovingCar` component to provide more visually constant speed along the track.

Previously, while using normalized arc length parameterization, the accuracy might have been insufficient for a complex curve like the Monaco track, leading to perceived speed variations.

Changes:
- In `app/component/f1/MovingCar.tsx`:
    - Increased `trackPathCurve.arcLengthDivisions` to 300 (from the default of 200) within a `useEffect` hook.
    - Called `trackPathCurve.getLength()` within the same effect to ensure that the curve's internal arc length calculations are primed with the new division count.

This should result in a more accurate mapping of the normalized curve parameter `u` to actual distances along the curve, making the car's speed appear more uniform across both straight and curved sections of the track. The overall speed is still determined by the `speed` prop passed from `F1MonacoScene.tsx` (currently `0.05`, leading to a ~20 second lap time).