### PR TITLE
Fix: Align white track line with SVG track by flipping Z-coordinate

### DIFF
--- a/pages/f1-monaco.tsx
+++ b/pages/f1-monaco.tsx
@@ -157,7 +157,7 @@ const TrackPathLine: React.FC<TrackPathLineProps> = ({ trackPathCurve }) => {
     if (!trackPathCurve) return null;
     const yLevelForLine = 0.16;
     // Reverted p.x, p.y mapping here
-    const linePoints = trackPathCurve.getPoints(100).map(p => new THREE.Vector3(p.x, yLevelForLine, p.y));
+    const linePoints = trackPathCurve.getPoints(100).map(p => new THREE.Vector3(p.x, yLevelForLine, -p.y));
     return new THREE.BufferGeometry().setFromPoints(linePoints);
   }, [trackPathCurve]);
 


### PR DESCRIPTION
This commit addresses a persistent issue where the white `TrackPathLine` was not correctly aligned with the extruded SVG track in the F1 Monaco scene.

Based on your feedback to "flip the white line 180degree upward," the Z-coordinate for the points defining the `TrackPathLine` has been negated.

In `pages/f1-monaco.tsx`, within the `TrackPathLine` component:
- The point mapping was changed from `new THREE.Vector3(p.x, yLevelForLine, p.y)` to `new THREE.Vector3(p.x, yLevelForLine, -p.y)`.
- `yLevelForLine` is maintained at `0.16` (0.01 units above the calculated track surface of Y=0.15).

This change should correctly orient the white line to match the extruded track geometry in the XZ plane, while maintaining the correct height. You will verify this alignment in your environment.