### PR TITLE
Fix: Align moving car path with corrected track orientation

### DIFF
--- a/app/component/f1/MovingCar.tsx
+++ b/app/component/f1/MovingCar.tsx
@@ -42,8 +42,8 @@ export const MovingCar = memo(function MovingCar({
     const p = trackPathCurve.getPointAt(t);
     const tan = trackPathCurve.getTangentAt(t);
 
-    ref.current.position.set(p.x, fixedY, p.y);
-    ref.current.lookAt(p.x + tan.x, fixedY, p.y + tan.y);
+    ref.current.position.set(p.x, fixedY, -p.y);
+    ref.current.lookAt(p.x + tan.x, fixedY, -(p.y + tan.y));
   });
 
   // Always render the fallback box


### PR DESCRIPTION
This commit updates the `MovingCar` component to ensure the cars correctly follow the track path, which was recently realigned by negating its Z-coordinates (the "flip" operation).

In `app/component/f1/MovingCar.tsx`, within the `useFrame` callback:
- The Z-coordinate for the car's position, derived from `p.y` of the `trackPathCurve` point, has been changed from `p.y` to `-p.y`.
- The Z-coordinate for the `lookAt` target, derived from `p.y + tan.y`, has been changed to `-(p.y + tan.y)`.

These changes ensure the cars' movement is consistent with the corrected `TrackPathLine` and the underlying extruded SVG track. Please verify this alignment in your environment.