### PR TITLE
Feat: Increase box height and adjust vertical position

### DIFF
--- a/app/component/f1/MovingCar.tsx
+++ b/app/component/f1/MovingCar.tsx
@@ -22,7 +22,7 @@ export const MovingCar = memo(function MovingCar({
 
   // useEffect(() => { ... }); // Removed GLTF error handling effect
 
-  const fixedY = useMemo(() => 0.15 + 0.3 / 2, []);
+  const fixedY = useMemo(() => 0.36, []);
 
   useEffect(() => {
     if (trackPathCurve) {
@@ -49,7 +49,7 @@ export const MovingCar = memo(function MovingCar({
   // Always render the fallback box
   return (
     <mesh ref={ref} scale={0.2} castShadow receiveShadow>
-      <boxGeometry args={[0.5, 0.2, 1.0]} /> {/* Changed dimensions */}
+      <boxGeometry args={[0.5, 0.4, 1.0]} /> {/* Changed dimensions */}
       <meshStandardMaterial color="orange" />
     </mesh>
   );


### PR DESCRIPTION
This commit implements your request to increase the vertical height of the moving boxes (cars) by 100% and ensures they remain correctly positioned on the track.

In `app/component/f1/MovingCar.tsx`:
- The Y-dimension of the `boxGeometry` arguments has been changed from `0.2` to `0.4`, effectively doubling the box height.
- The `fixedY` constant, which determines the Y-coordinate of the car's center, has been updated from `0.3` to `0.36`. This change positions the bottom of the now taller boxes at `Y=0.16`, aligning them with the white track line.