### PR TITLE
Fix: Fine-tune car vertical position to be minimally above track

### DIFF
--- a/app/component/f1/MovingCar.tsx
+++ b/app/component/f1/MovingCar.tsx
@@ -22,7 +22,7 @@ export const MovingCar = memo(function MovingCar({
 
   // useEffect(() => { ... }); // Removed GLTF error handling effect
 
-  const fixedY = useMemo(() => 0.36, []);
+  const fixedY = useMemo(() => 0.351, []);
 
   useEffect(() => {
     if (trackPathCurve) {


### PR DESCRIPTION
This commit adjusts the `fixedY` value for the moving cars to position them very close to the SVG track surface, as per your feedback.

In `app/component/f1/MovingCar.tsx`:
- The `fixedY` constant, determining the Y-coordinate of the car's center, has been changed from `0.36` to `0.351`.

With a car height of 0.4, this change places the bottom of the car at Y=0.151, which is 0.001 units above the track surface (Y=0.15). This provides a minimal gap, addressing the "just above the svg" requirement.